### PR TITLE
Reimplementation of Hooks.cs

### DIFF
--- a/Hooks.cs
+++ b/Hooks.cs
@@ -93,6 +93,7 @@ namespace Core.FsmUtil
                 catch (Exception ex)
                 {
                     logger.LogError(ex);
+                    int_Logger.Log(ex.ToString());
                 }
             }
         }

--- a/Hooks.cs
+++ b/Hooks.cs
@@ -93,7 +93,7 @@ namespace Core.FsmUtil
                 catch (Exception ex)
                 {
                     logger.LogError(ex);
-                    int_Logger.Log(ex.ToString());
+                    Core.FsmUtil.Logger.Log(ex.ToString());
                 }
             }
         }

--- a/Hooks.cs
+++ b/Hooks.cs
@@ -1,45 +1,13 @@
-﻿using Core.FsmUtil.delegates;
+using System;
+using System.ComponentModel;
+using Core.FsmUtil.delegates;
 
 namespace Core.FsmUtil
 {
     namespace delegates
     {
-        /// <summary>
-        ///     Hook that gets called before `PlayMakerFSM.Awake()` is called.  
-        ///     In this hook, nothing in the FSM will be initialized yet.
-        /// </summary>
-        public delegate void PmFsmBeforeAwake(PlayMakerFSM fsm);
-
-        /// <summary>
-        ///     Hook that gets called after `PlayMakerFSM.Awake()` is called.  
-        ///     In this hook, the PlayMakerGlobals will be initialized as well as the FSM template, if present, and the FSM itself.
-        /// </summary>
-        public delegate void PmFsmAfterAwake(PlayMakerFSM fsm);
-
-        /// <summary>
-        ///     Hook that gets called before `PlayMakerFSM.Start()` is called.  
-        ///     In this hook, the FSM didn't execute any state actions yet, nor is the current state set, if it didn't already start.  
-        ///     This is likely the hook for editing FSMs that you want.
-        /// </summary>
-        public delegate void PmFsmBeforeStart(PlayMakerFSM fsm);
-
-        /// <summary>
-        ///     Hook that gets called after `PlayMakerFSM.Start()` is called.  
-        ///     In this hook, the FSM switched to its first state and started executing it.
-        /// </summary>
-        public delegate void PmFsmAfterStart(PlayMakerFSM fsm);
-
-        /// <summary>
-        ///     Hook that gets called before `PlayMakerFSM.OnEnable()` is called.  
-        ///     In this hook, the FSM is not added to the static `fsmList` yet, nor did the FSM restart if the `RestartOnEnable` flag is set.
-        /// </summary>
-        public delegate void PmFsmBeforeOnEnable(PlayMakerFSM fsm);
-
-        /// <summary>
-        ///     Hook that gets called after `PlayMakerFSM.OnEnable()` is called.  
-        ///     In this hook, the FSM is added to the static `fsmList` and restarted if the `RestartOnEnable` flag is set.
-        /// </summary>
-        public delegate void PmFsmAfterOnEnable(PlayMakerFSM fsm);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public delegate void FsmModificationHandler(PlayMakerFSM fsm);
     }
 
     /// <summary>
@@ -47,122 +15,86 @@ namespace Core.FsmUtil
     /// </summary>
     public static class Hooks
     {
-        /// <summary>
-        ///     Hook that gets called before `PlayMakerFSM.Awake()` is called.
-        /// </summary>
-        /// <see cref="PmFsmBeforeAwake"/>
-        /// <remarks>N/A</remarks>
-        public static event PmFsmBeforeAwake PmFsmBeforeAwakeHook;
+        private static Modding.ILogger logger = new Modding.SimpleLogger("Core.FsmUtil.Hooks");
 
-        /// <summary>
-        ///     Hook that gets called after `PlayMakerFSM.Awake()` is called.
-        /// </summary>
-        /// <see cref="PmFsmAfterAwake"/>
-        /// <remarks>N/A</remarks>
-        public static event PmFsmAfterAwake PmFsmAfterAwakeHook;
-
+        private static FsmModificationHandler _pmFsmBeforeStartHook;
+        private static void InvokeBeforeStartHook(On.PlayMakerFSM.orig_Start orig, PlayMakerFSM self)
+        {
+            InvokeAll(_pmFsmBeforeStartHook, self);
+            orig(self);
+        }
         /// <summary>
         ///     Hook that gets called before `PlayMakerFSM.Start()` is called.
         /// </summary>
-        /// <see cref="PmFsmBeforeStart"/>
-        /// <remarks>N/A</remarks>
-        public static event PmFsmBeforeStart PmFsmBeforeStartHook;
+        public static event FsmModificationHandler PmFsmBeforeStartHook
+        {
+            add
+            {
+                if (_pmFsmBeforeStartHook == null)
+                {
+                    On.PlayMakerFSM.Start += InvokeBeforeStartHook;
+                }
+                _pmFsmBeforeStartHook += value;
+            }
+            remove
+            {
+                _pmFsmBeforeStartHook -= value;
+                if (_pmFsmBeforeStartHook == null)
+                {
+                    On.PlayMakerFSM.Start -= InvokeBeforeStartHook;
+                }
+            }
+        }
 
-        /// <summary>
-        ///     Hook that gets called after `PlayMakerFSM.Start()` is called.
-        /// </summary>
-        /// <see cref="PmFsmAfterStart"/>
-        /// <remarks>N/A</remarks>
-        public static event PmFsmAfterStart PmFsmAfterStartHook;
-
-        /// <summary>
-        ///     Hook that gets called before `PlayMakerFSM.OnEnable()` is called.
-        /// </summary>
-        /// <see cref="PmFsmBeforeOnEnable"/>
-        /// <remarks>N/A</remarks>
-        public static event PmFsmBeforeOnEnable PmFsmBeforeOnEnableHook;
-
+        private static FsmModificationHandler _pmFsmAfterOnEnableHook;
+        private static void InvokeAfterOnEnableHook(On.PlayMakerFSM.orig_OnEnable orig, PlayMakerFSM self)
+        {
+            orig(self);
+            InvokeAll(_pmFsmAfterOnEnableHook, self);
+        }
         /// <summary>
         ///     Hook that gets called after `PlayMakerFSM.OnEnable()` is called.
         /// </summary>
-        /// <see cref="PmFsmAfterOnEnable"/>
-        /// <remarks>N/A</remarks>
-        public static event PmFsmAfterOnEnable PmFsmAfterOnEnableHook;
-
-        static Hooks()
+        public static event FsmModificationHandler PmFsmAfterOnEnableHook
         {
-            On.PlayMakerFSM.Awake += (orig, self) =>
+            add
             {
-                if (PmFsmBeforeAwakeHook != null)
+                if (_pmFsmAfterOnEnableHook == null)
                 {
-                    PmFsmBeforeAwake[] delegates = PmFsmBeforeAwakeHook.GetInvocationList() as PmFsmBeforeAwake[];
-                    int delegatesCount = delegates.Length;
-                    int i;
-                    for (i = 0; i < delegatesCount; i++)
-                    {
-                        delegates[i].Invoke(self);
-                    }
+                    On.PlayMakerFSM.OnEnable += InvokeAfterOnEnableHook;
                 }
-                orig(self);
-                if (PmFsmAfterAwakeHook != null)
-                {
-                    PmFsmAfterAwake[] delegates = PmFsmAfterAwakeHook.GetInvocationList() as PmFsmAfterAwake[];
-                    int delegatesCount = delegates.Length;
-                    int i;
-                    for (i = 0; i < delegatesCount; i++)
-                    {
-                        delegates[i].Invoke(self);
-                    }
-                }
-            };
-            On.PlayMakerFSM.Start += (orig, self) =>
+                _pmFsmAfterOnEnableHook += value;
+            }
+            remove
             {
-                if (PmFsmBeforeStartHook != null)
+                _pmFsmAfterOnEnableHook -= value;
+                if (_pmFsmAfterOnEnableHook == null)
                 {
-                    PmFsmBeforeStart[] delegates = PmFsmBeforeStartHook.GetInvocationList() as PmFsmBeforeStart[];
-                    int delegatesCount = delegates.Length;
-                    int i;
-                    for (i = 0; i < delegatesCount; i++)
-                    {
-                        delegates[i].Invoke(self);
-                    }
+                    On.PlayMakerFSM.OnEnable -= InvokeAfterOnEnableHook;
                 }
-                orig(self);
-                if (PmFsmAfterStartHook != null)
-                {
-                    PmFsmAfterStart[] delegates = PmFsmAfterStartHook.GetInvocationList() as PmFsmAfterStart[];
-                    int delegatesCount = delegates.Length;
-                    int i;
-                    for (i = 0; i < delegatesCount; i++)
-                    {
-                        delegates[i].Invoke(self);
-                    }
-                }
-            };
-            On.PlayMakerFSM.OnEnable += (orig, self) =>
+            }
+        }
+
+        private static void InvokeAll(FsmModificationHandler handler, PlayMakerFSM fsm)
+        {
+            if (handler == null)
             {
-                if (PmFsmBeforeOnEnableHook != null)
+                return;
+            }
+
+            Delegate[] invocationList = handler.GetInvocationList();
+
+            for (int i = 0; i < invocationList.Length; i++)
+            {
+                try
                 {
-                    PmFsmBeforeOnEnable[] delegates = PmFsmBeforeOnEnableHook.GetInvocationList() as PmFsmBeforeOnEnable[];
-                    int delegatesCount = delegates.Length;
-                    int i;
-                    for (i = 0; i < delegatesCount; i++)
-                    {
-                        delegates[i].Invoke(self);
-                    }
+                    (invocationList[i] as FsmModificationHandler).Invoke(fsm);
                 }
-                orig(self);
-                if (PmFsmAfterOnEnableHook != null)
+                catch (Exception ex)
                 {
-                    PmFsmAfterOnEnable[] delegates = PmFsmAfterOnEnableHook.GetInvocationList() as PmFsmAfterOnEnable[];
-                    int delegatesCount = delegates.Length;
-                    int i;
-                    for (i = 0; i < delegatesCount; i++)
-                    {
-                        delegates[i].Invoke(self);
-                    }
+                    logger.LogError(ex);
                 }
-            };
+            }
         }
     }
 }


### PR DESCRIPTION
Summary of changes:

* Only offer the before start and after onenable hooks. Actually I think only one should be offered - if people need to use a different hook (which is unlikely) then they can write their own. I've left two because I'm not convinced that .Start is enough to catch fsm template memes on objects that are re-enabled.

* Instead of subscribing to the monomod hook in the static constructor, subscribe to the monomod hook when the FsmUtil event gets a subscriber; this way, it becomes possible to unsubscribe from the monomod event.

* Single delegate type for fsm modifications (my personal preference is just to use Action<PlayMakerFSM> actually).

* Provide error handling/logging, so one mod is less likely to break things for everyone else.

* Log errors to modlog rather than debug log, because that's where they logically belong.

* Documentation on the event rather than the delegate type because that's where it logically belongs.